### PR TITLE
Refactor into separate `.git` and `.pkg` components.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -38,6 +38,7 @@
 	},
 
 	"globals": {
-		"console": false
+		"console": false,
+		"Promise": true
 	}
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,12 @@
+sudo: false
 language: node_js
 node_js:
-- '0.11'
+- '0.12'
 - '0.10'
+- '0.8'
+- 'iojs-1'
+before_install:
+- npm install -g "npm@>=1.4.6"
+after_success:
+- npm install coveralls
+- cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js

--- a/README.md
+++ b/README.md
@@ -1,9 +1,49 @@
-# version
+# express-version
 
-Automatically publish package.json and git version information out over your app.
+Automatically publish package.json and git information out over your app.
+
+![build status](http://img.shields.io/travis/izaakschroeder/express-version.svg?style=flat)
+![coverage](http://img.shields.io/coveralls/izaakschroeder/express-version.svg?style=flat)
+![license](http://img.shields.io/npm/l/express-version.svg?style=flat)
+![version](http://img.shields.io/npm/v/express-version.svg?style=flat)
+![downloads](http://img.shields.io/npm/dm/express-version.svg?style=flat)
 
 ```javascript
+var express = require('express'),
+	version = require('express-version');
+
 var app = express();
-// Path to the folder containing package.json
-app.use(version(__dirname));
+
+app.use(version.pkg());
+app.use(version.git());
+```
+
+## Usage
+
+### .git
+
+You can export `branch`, `commit` or `tags` as a header. The defaults are shown below:
+```javascript
+version.git({
+	path: process.cwd(),
+	headers: {
+		'X-Branch': 'branch',
+		'X-Commit': 'commit',
+		'X-Tags': 'tags'
+	}
+});
+```
+
+### .pkg
+
+You can export any field in the `package.json` file as a header. The defaults are shown below:
+
+```javascript
+version.pkg({
+	path: process.cwd(),
+	headers: {
+		'X-Name': 'name',
+		'X-Version': 'version'
+	}
+});
 ```

--- a/lib/git.js
+++ b/lib/git.js
@@ -1,0 +1,84 @@
+
+'use strict';
+
+var _ = require('lodash'),
+	Promise = require('bluebird'),
+	ChildProcess = require('child_process');
+
+function Repository(dir) {
+	if (!_.isString(dir)) {
+		throw new TypeError();
+	}
+	this.path = dir;
+}
+
+Repository.prototype.git = function git(args) {
+	var self = this;
+	return new Promise(function gitResolve(resolve, reject) {
+		ChildProcess.execFile('git', args, {
+			cwd: self.path
+		}, function gitComplete(err, result) {
+			if (err) {
+				reject(err);
+			} else {
+				resolve(result.trim());
+			}
+		});
+	});
+};
+
+Repository.prototype.getBranch = function getBranch() {
+	return this.git(['rev-parse', '--verify', '--abbrev-ref', 'HEAD']);
+};
+
+Repository.prototype.getCommit = function getCommit() {
+	return this.git(['rev-parse', '--verify', 'HEAD']);
+};
+
+Repository.prototype.getTags = function getTag() {
+	return this.git(['tag', '--points-at', 'HEAD']);
+};
+
+Repository.prototype.getInfo = function getInfo() {
+	return Promise.props({
+		branch: this.getBranch(),
+		commit: this.getCommit(),
+		tags: this.getTags()
+	});
+};
+
+
+
+module.exports = function versionable(options) {
+
+	if (_.isString(options)) {
+		options = { path: options };
+	}
+
+	options = _.assign({
+		path: process.cwd(),
+		headers: {
+			'X-Commit': 'commit',
+			'X-Branch': 'branch',
+			'X-Tags': 'tags'
+		}
+	}, options);
+
+	var repo = new Repository(options.path), promisedHeaders;
+
+	promisedHeaders = repo.getInfo().then(function gotInfo(info) {
+		return _.mapValues(options.headers, function mapHeader(key) {
+			return info[key];
+		});
+	}).catch(_.noop);
+
+	return function version(req, res, next) {
+		promisedHeaders
+			.then(function gotHeaders(headers) {
+				_.forEach(headers, function outputHeader(value, header) {
+					res.set(header, value);
+				});
+			})
+			.finally(next);
+	};
+};

--- a/lib/package.js
+++ b/lib/package.js
@@ -1,0 +1,56 @@
+
+'use strict';
+
+var _ = require('lodash'),
+	fs = require('fs'),
+	path = require('path'),
+	Promise = require('bluebird');
+
+function manifest(root) {
+
+	if (!_.isString(root)) {
+		throw new TypeError();
+	}
+
+	return new Promise(function manfiestPromise(resolve, reject) {
+		var file = path.join(root, 'package.json');
+		fs.readFile(file, 'utf8', function manifestRead(err, data) {
+			if (err) {
+				reject(err);
+			} else {
+				resolve(JSON.parse(data));
+			}
+		});
+	});
+}
+
+
+module.exports = function versionable(options) {
+	if (_.isString(options)) {
+		options = { path: options };
+	}
+
+	options = _.assign({
+		path: process.cwd(),
+		headers: {
+			'X-Name': 'name',
+			'X-Version': 'version'
+		}
+	}, options);
+
+	var promisedHeaders = manifest(options.path).then(function gotPkg(pkg) {
+		return _.mapValues(options.headers, function mapValue(key) {
+			return pkg[key];
+		});
+	}).catch(_.noop);
+
+	return function version(req, res, next) {
+		promisedHeaders
+			.then(function gotHeaders(headers) {
+				_.forEach(headers, function outputHeader(value, header) {
+					res.set(header, value);
+				});
+			})
+			.finally(next);
+	};
+};

--- a/lib/version.js
+++ b/lib/version.js
@@ -1,27 +1,7 @@
 
 'use strict';
 
-var fs = require('fs'),
-	path = require('path');
-
-function collect(root) {
-	var manifest = JSON.parse(fs.readFileSync(path.join(root, 'package.json'), 'utf8')),
-		branch = fs.readFileSync(path.join(root, '.git', 'HEAD'), 'utf8').match(/ref:\s*refs\/heads\/(.*)/)[1],
-		commit = fs.readFileSync(path.join(root, '.git', 'refs', 'heads', branch), 'utf8');
-	return {
-		version: manifest.version,
-		branch: branch,
-		commit: commit
-	};
-}
-
-module.exports = function versionable(path) {
-	var info = collect(path);
-	return function version(req, res, next) {
-		res
-			.set('X-App-Version', info.version)
-			.set('X-App-Commit', info.commit)
-			.set('X-App-Branch', info.branch);
-		next();
-	};
+module.exports = {
+	git: require('./git'),
+	pkg: require('./package')
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "express-version",
-	"version": "0.1.0",
+	"version": "0.2.0",
 	"author": "Izaak Schroeder <izaak.schroeder@gmail.com>",
 	"scripts": {
 		"test": "npm run lint && npm run spec && npm run coverage",
@@ -9,11 +9,15 @@
 		"coverage": "istanbul check-coverage --statement 100 --branch 100 --function 100"
 	},
 	"main": "lib/version.js",
+	"dependencies": {
+		"bluebird": "^2.9.7",
+		"lodash": "^3.1.0"
+	},
 	"peerDependencies": {
-		"express": "4.x"
+		"express": "^4.11.2"
 	},
 	"devDependencies": {
-		"express": "4.x",
+		"express": "^4.11.2",
 		"eslint": "*",
 		"eslint-plugin-nodeca": "*",
 		"mocha": "*",

--- a/test/spec/git.spec.js
+++ b/test/spec/git.spec.js
@@ -1,0 +1,105 @@
+
+'use strict';
+
+var childProcess = require('child_process'),
+	express = require('express'),
+	request = require('supertest'),
+	git = require('git');
+
+function ok(req, res, next) {
+	res.status(200).send({ ok: true });
+	next();
+}
+
+
+describe('.git', function() {
+
+	var sandbox;
+
+	beforeEach(function() {
+		sandbox = sinon.sandbox.create();
+	});
+
+	afterEach(function() {
+		sandbox.restore();
+	});
+
+	it('should fail with no path', function() {
+		expect(function() {
+			git({ path: null });
+		}).to.throw(TypeError);
+	});
+
+	describe('invalid repo', function() {
+		var app;
+
+		beforeEach(function() {
+			sandbox.stub(childProcess, 'execFile').callsArgWith(3, 'err');
+			app = express();
+			app.use(git('fakepath'));
+			app.get('/', ok);
+		});
+
+		afterEach(function() {
+			app = null;
+		});
+
+		it('should omit the header', function(done) {
+			request(app)
+				.get('/')
+				.expect(function(res) {
+					expect(res).to.have.status(200);
+					expect(res).to.not.have.header('X-Commit');
+				})
+				.end(done);
+		});
+	});
+
+	describe('default behavior', function() {
+		var app;
+
+		beforeEach(function() {
+			sandbox.stub(childProcess, 'execFile')
+				.onCall(0).callsArgWith(3, null, 'branch')
+				.onCall(1).callsArgWith(3, null, '123')
+				.onCall(2).callsArgWith(3, null, 'v0.1.1');
+			app = express();
+			app.use(git('fakepath'));
+			app.get('/', ok);
+		});
+
+		afterEach(function() {
+			app = null;
+		});
+
+		it('should get correct commit', function(done) {
+			request(app)
+				.get('/')
+				.expect(function(res) {
+					expect(res).to.have.status(200);
+					expect(res).to.have.header('X-Commit', '123');
+				})
+				.end(done);
+		});
+
+		it('should get correct branch', function(done) {
+			request(app)
+				.get('/')
+				.expect(function(res) {
+					expect(res).to.have.status(200);
+					expect(res).to.have.header('X-Branch', 'branch');
+				})
+				.end(done);
+		});
+
+		it('should get correct tags', function(done) {
+			request(app)
+				.get('/')
+				.expect(function(res) {
+					expect(res).to.have.status(200);
+					expect(res).to.have.header('X-Tags', 'v0.1.1');
+				})
+				.end(done);
+		});
+	});
+});

--- a/test/spec/package.spec.js
+++ b/test/spec/package.spec.js
@@ -1,0 +1,86 @@
+
+'use strict';
+
+var fs = require('fs'),
+	express = require('express'),
+	request = require('supertest'),
+	pkg = require('package');
+
+function ok(req, res, next) {
+	res.status(200).send({ ok: true });
+	next();
+}
+
+describe('.pkg', function() {
+
+	var sandbox;
+
+	beforeEach(function() {
+		sandbox = sinon.sandbox.create();
+	});
+
+	afterEach(function() {
+		sandbox.restore();
+	});
+
+	it('should fail with no path', function() {
+		expect(function() {
+			pkg({ path: null });
+		}).to.throw(TypeError);
+	});
+
+	describe('invalid package', function() {
+		var app;
+
+		beforeEach(function() {
+			sandbox.stub(fs, 'readFile').callsArgWith(2, 'error');
+			app = express();
+			app.use(pkg('fakepath'));
+			app.get('/', ok);
+		});
+
+		afterEach(function() {
+			app = null;
+		});
+
+		it('should omit the header', function(done) {
+			request(app)
+				.get('/')
+				.expect(function(res) {
+					expect(res).to.have.status(200);
+					expect(res).to.not.have.header('X-Version');
+				})
+				.end(done);
+		});
+	});
+
+	describe('default behavior', function() {
+		var app;
+
+		beforeEach(function() {
+			sandbox.stub(fs, 'readFile').callsArgWith(2, null, JSON.stringify({
+				name: 'test',
+				version: '2.1.1'
+			}));
+			app = express();
+			app.use(pkg('fakepath'));
+			app.get('/', ok);
+		});
+
+		afterEach(function() {
+			app = null;
+		});
+
+		it('should get correct version', function(done) {
+			request(app)
+				.get('/')
+				.expect(function(res) {
+					expect(res).to.have.status(200);
+					expect(res).to.have.header('X-Version', '2.1.1');
+				})
+				.end(done);
+		});
+	});
+
+
+});

--- a/test/spec/version.spec.js
+++ b/test/spec/version.spec.js
@@ -1,57 +1,13 @@
 
 'use strict';
 
-var fs = require('fs'),
-	path = require('path'),
-	express = require('express'),
-	version = require('version'),
-	request = require('supertest');
+var version = require('version');
 
-function ok(req, res, next) {
-	res.status(200).send({ ok: true });
-	next();
-}
-
-function error(error, req, res, next) {
-	res.status(error.statusCode || 500).send(error);
-	next(error);
-}
-
-describe('#allows', function() {
-
-	beforeEach(function() {
-		this.app = express();
-		this.app.use(error);
+describe('version', function() {
+	it('should export `.git`', function() {
+		expect(version).to.have.property('git');
 	});
-
-	afterEach(function() {
-		this.app = null;
+	it('should export `.pkg`', function() {
+		expect(version).to.have.property('pkg');
 	});
-
-	it('it should respond with correct version information', sinon.test(function(done) {
-		this.stub(fs, 'readFileSync', function(file) {
-			switch (path.basename(file)) {
-			case 'package.json':
-				return '{ "version": "1.1.2" }';
-			case 'HEAD':
-				return 'ref: refs/heads/master';
-			case 'master':
-				return 'abcdef';
-			default:
-				throw new Error();
-			}
-		});
-		this.app.use(version('__fakepath'));
-		this.app.get('/', ok);
-		request(this.app)
-			.get('/')
-			.expect(function(res) {
-				expect(res).to.have.status(200);
-				expect(res).to.have.header('X-App-Version', '1.1.2');
-				expect(res).to.have.header('X-App-Branch', 'master');
-				expect(res).to.have.header('X-App-Commit', 'abcdef');
-			})
-			.end(done);
-	}));
-
 });


### PR DESCRIPTION
Offers more control over each type of versioning including how their information is displayed in headers.
